### PR TITLE
Feature: Auto-Block incorrect chronomatron puzzle solution

### DIFF
--- a/src/main/java/me/Danker/DankersSkyblockMod.java
+++ b/src/main/java/me/Danker/DankersSkyblockMod.java
@@ -2883,6 +2883,8 @@ public class DankersSkyblockMod
     			if (ToggleCommand.chronomatronToggled && inventoryName.startsWith("Chronomatron (")) {
     				if (inventory.getStackInSlot(49).getDisplayName().startsWith("§7Timer: §a") && (item == null || item.getItem() == Item.getItemFromBlock(Blocks.stained_glass) || item.getItem() == Item.getItemFromBlock(Blocks.stained_hardened_clay))) {
     					chronomatronMouseClicks++;
+					} else if(inventory.getStackInSlot(49).getDisplayName().startsWith("§aRemember the pattern!")) {
+    					if(event.isCancelable()) event.setCanceled(true);
 					}
 				}
 

--- a/src/main/java/me/Danker/DankersSkyblockMod.java
+++ b/src/main/java/me/Danker/DankersSkyblockMod.java
@@ -1,7 +1,6 @@
 package me.Danker;
 
 import com.google.gson.JsonObject;
-import com.mojang.realmsclient.util.RealmsUtil;
 import me.Danker.commands.*;
 import me.Danker.gui.*;
 import me.Danker.handlers.*;
@@ -14,7 +13,6 @@ import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiChat;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.gui.inventory.GuiChest;
-import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItemFrame;
@@ -2883,7 +2881,7 @@ public class DankersSkyblockMod
     			if (ToggleCommand.chronomatronToggled && inventoryName.startsWith("Chronomatron (")) {
     				if (inventory.getStackInSlot(49).getDisplayName().startsWith("§7Timer: §a") && (item == null || item.getItem() == Item.getItemFromBlock(Blocks.stained_glass) || item.getItem() == Item.getItemFromBlock(Blocks.stained_hardened_clay))) {
 						if(!item.getDisplayName().equals(chronomatronPattern.get(chronomatronMouseClicks))) {
-							if(event.isCancelable()) event.setCanceled(true);
+							if(event.isCancelable() && !Keyboard.isKeyDown(Keyboard.KEY_LSHIFT) && !Keyboard.isKeyDown(Keyboard.KEY_RSHIFT)) event.setCanceled(true);
 							return;
 						}
     					chronomatronMouseClicks++;

--- a/src/main/java/me/Danker/DankersSkyblockMod.java
+++ b/src/main/java/me/Danker/DankersSkyblockMod.java
@@ -2882,9 +2882,14 @@ public class DankersSkyblockMod
 
     			if (ToggleCommand.chronomatronToggled && inventoryName.startsWith("Chronomatron (")) {
     				if (inventory.getStackInSlot(49).getDisplayName().startsWith("§7Timer: §a") && (item == null || item.getItem() == Item.getItemFromBlock(Blocks.stained_glass) || item.getItem() == Item.getItemFromBlock(Blocks.stained_hardened_clay))) {
+						if(!item.getDisplayName().equals(chronomatronPattern.get(chronomatronMouseClicks))) {
+							if(event.isCancelable()) event.setCanceled(true);
+							return;
+						}
     					chronomatronMouseClicks++;
 					} else if(inventory.getStackInSlot(49).getDisplayName().startsWith("§aRemember the pattern!")) {
     					if(event.isCancelable()) event.setCanceled(true);
+    					return;
 					}
 				}
 


### PR DESCRIPTION
Cancels click event if the user clicks the incorrect color in the sequence, can be overridden by holding shift and clicking.