### PR TITLE
Feature Update

### DIFF
--- a/src/main/java/me/Danker/DankersSkyblockMod.java
+++ b/src/main/java/me/Danker/DankersSkyblockMod.java
@@ -2896,7 +2896,24 @@ public class DankersSkyblockMod
     			ItemStack item = mouseSlot.getStack();
     			String inventoryName = inventory.getDisplayName().getUnformattedText();
 
-    			if (inventoryName.endsWith(" Chest") && item != null && item.getDisplayName().contains("Open Reward Chest")) {
+				if(ToggleCommand.stopSalvageStarredToggled && inventoryName.startsWith("Salvage")) {
+					if(item == null) return;
+					boolean inSalvageGui = false;
+					if(item.getDisplayName().contains("Salvage") || item.getDisplayName().contains("Essence")) {
+						ItemStack salvageItem = inventory.getStackInSlot(13);
+						if(salvageItem == null) return;
+						item = salvageItem;
+						inSalvageGui = true;
+					}
+					if (item.getDisplayName().contains("✪") && (mouseSlot.slotNumber > 53 || inSalvageGui)) {
+						Minecraft.getMinecraft().thePlayer.playSound("note.bass", 1, 0.5f);
+						Minecraft.getMinecraft().thePlayer.addChatMessage(new ChatComponentText(ERROR_COLOUR + "Danker's Skyblock Mod has stopped you from salvaging that item!"));
+						event.setCanceled(true);
+						return;
+					}
+				}
+
+				if (inventoryName.endsWith(" Chest") && item != null && item.getDisplayName().contains("Open Reward Chest")) {
     				List<String> tooltip = item.getTooltip(Minecraft.getMinecraft().thePlayer, Minecraft.getMinecraft().gameSettings.advancedItemTooltips);
     				for (String lineUnclean : tooltip) {
     					String line = StringUtils.stripControlCodes(lineUnclean);

--- a/src/main/java/me/Danker/DankersSkyblockMod.java
+++ b/src/main/java/me/Danker/DankersSkyblockMod.java
@@ -14,6 +14,7 @@ import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.GuiChat;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.gui.inventory.GuiChest;
+import net.minecraft.client.settings.GameSettings;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.item.EntityItemFrame;
@@ -120,6 +121,8 @@ public class DankersSkyblockMod
 	static int chronomatronMouseClicks = 0;
 	static int lastUltraSequencerClicked = 0;
 	static ItemStack[] experimentTableSlots = new ItemStack[54];
+	static int pickBlockBind;
+	static boolean pickBlockBindSwapped = false;
 
 	static double dungeonStartTime = 0;
     static double bloodOpenTime = 0;
@@ -3003,6 +3006,30 @@ public class DankersSkyblockMod
 
     @SubscribeEvent
 	public void onGuiOpen(GuiOpenEvent event) {
+    	Minecraft mc = Minecraft.getMinecraft();
+    	GameSettings gameSettings = mc.gameSettings;
+		if (event.gui instanceof GuiChest) {
+			Container containerChest = ((GuiChest) event.gui).inventorySlots;
+			if (containerChest instanceof ContainerChest) {
+				GuiChest chest = (GuiChest) event.gui;
+				IInventory inventory = ((ContainerChest) containerChest).getLowerChestInventory();
+				String inventoryName = inventory.getDisplayName().getUnformattedText();
+				if(ToggleCommand.swapToPickBlockInExperimentsToggled) {
+					if(inventoryName.startsWith("Chronomatron (") || inventoryName.startsWith("Superpairs (") || inventoryName.startsWith("Ultrasequencer (")) {
+						if(!pickBlockBindSwapped) {
+							pickBlockBind = gameSettings.keyBindPickBlock.getKeyCode();
+							gameSettings.keyBindPickBlock.setKeyCode(-100);
+							pickBlockBindSwapped = true;
+						}
+					} else {
+						if(pickBlockBindSwapped) {
+							gameSettings.keyBindPickBlock.setKeyCode(pickBlockBind);
+							pickBlockBindSwapped = false;
+						}
+					}
+				}
+			}
+		}
 		clickInOrderSlots = new Slot[36];
 		lastChronomatronRound = 0;
 		chronomatronPattern.clear();

--- a/src/main/java/me/Danker/DankersSkyblockMod.java
+++ b/src/main/java/me/Danker/DankersSkyblockMod.java
@@ -7,6 +7,7 @@ import me.Danker.handlers.*;
 import me.Danker.utils.TicTacToeUtils;
 import me.Danker.utils.Utils;
 import net.minecraft.block.Block;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.gui.Gui;
@@ -2778,6 +2779,52 @@ public class DankersSkyblockMod
     			event.setCanceled(true);
     		}
     	}
+
+		if(event.action == PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK) {
+			IBlockState blockState = Minecraft.getMinecraft().theWorld.getBlockState(event.pos);
+			Block block = blockState.getBlock();
+			List<Block> interactables = Arrays.asList(
+					Blocks.acacia_door,
+					Blocks.acacia_fence_gate,
+					Blocks.anvil,
+					Blocks.beacon,
+					Blocks.bed,
+					Blocks.birch_door,
+					Blocks.birch_fence_gate,
+					Blocks.brewing_stand,
+					Blocks.command_block,
+					Blocks.chest,
+					Blocks.dark_oak_door,
+					Blocks.dark_oak_fence_gate,
+					Blocks.daylight_detector,
+					Blocks.daylight_detector_inverted,
+					Blocks.dispenser,
+					Blocks.dropper,
+					Blocks.enchanting_table,
+					Blocks.ender_chest,
+					Blocks.oak_fence_gate,
+					Blocks.furnace,
+					Blocks.hopper,
+					Blocks.jungle_door,
+					Blocks.jungle_fence_gate,
+					Blocks.lever,
+					Blocks.noteblock,
+					Blocks.powered_comparator,
+					Blocks.unpowered_comparator,
+					Blocks.powered_repeater,
+					Blocks.unpowered_repeater,
+					Blocks.standing_sign,
+					Blocks.wall_sign,
+					Blocks.trapdoor,
+					Blocks.trapped_chest,
+					Blocks.wall_sign,
+					Blocks.wooden_button,
+					Blocks.stone_button,
+					Blocks.oak_door,
+					Blocks.skull
+			);
+			if(!interactables.contains(block)) if(event.isCancelable()) event.setCanceled(true);
+		}
     }
 
     @SubscribeEvent

--- a/src/main/java/me/Danker/DankersSkyblockMod.java
+++ b/src/main/java/me/Danker/DankersSkyblockMod.java
@@ -3220,12 +3220,12 @@ public class DankersSkyblockMod
 						new Color(255, 199, 87, 100),
 						new Color(119, 105, 198, 100),
 						new Color(135, 199, 112, 100),
-						new Color(2100, 37, 2100, 100),
+						new Color(240, 37, 240, 100),
 						new Color(178, 132, 190, 100),
 						new Color(63, 135, 163, 100),
 						new Color(146, 74, 10, 100),
 						new Color(255, 255, 255, 100),
-						new Color(217, 252, 1100, 100),
+						new Color(217, 252, 140, 100),
 						new Color(255, 82, 82, 100)
 					};
 

--- a/src/main/java/me/Danker/DankersSkyblockMod.java
+++ b/src/main/java/me/Danker/DankersSkyblockMod.java
@@ -3213,20 +3213,20 @@ public class DankersSkyblockMod
 					}
 
         			Color[] colors = {
-						new Color(255, 0, 0, 40),
-						new Color(0, 0, 255, 40),
-						new Color(60, 179, 113, 40),
-						new Color(255, 114, 255, 40),
-						new Color(255, 199, 87, 40),
-						new Color(119, 105, 198, 40),
-						new Color(135, 199, 112, 40),
-						new Color(250, 37, 240, 40),
-						new Color(178, 132, 190, 40),
-						new Color(63, 135, 163, 40),
-						new Color(146, 74, 10, 40),
-						new Color(255, 255, 255, 40),
-						new Color(217, 252, 140, 40),
-						new Color(255, 82, 82, 40)
+						new Color(255, 0, 0, 60),
+						new Color(0, 0, 255, 60),
+						new Color(60, 179, 113, 60),
+						new Color(255, 114, 255, 60),
+						new Color(255, 199, 87, 60),
+						new Color(119, 105, 198, 60),
+						new Color(135, 199, 112, 60),
+						new Color(260, 37, 260, 60),
+						new Color(178, 132, 190, 60),
+						new Color(63, 135, 163, 60),
+						new Color(146, 74, 10, 60),
+						new Color(255, 255, 255, 60),
+						new Color(217, 252, 160, 60),
+						new Color(255, 82, 82, 60)
 					};
 
 					Iterator<Color> colorIterator = Arrays.stream(colors).iterator();

--- a/src/main/java/me/Danker/DankersSkyblockMod.java
+++ b/src/main/java/me/Danker/DankersSkyblockMod.java
@@ -2788,28 +2788,24 @@ public class DankersSkyblockMod
 			Block block = blockState.getBlock();
 			ArrayList<Block> interactables = new ArrayList<>(Arrays.asList(
 					Blocks.acacia_door,
-					Blocks.acacia_fence_gate,
 					Blocks.anvil,
 					Blocks.beacon,
 					Blocks.bed,
 					Blocks.birch_door,
-					Blocks.birch_fence_gate,
 					Blocks.brewing_stand,
 					Blocks.command_block,
+					Blocks.crafting_table,
 					Blocks.chest,
 					Blocks.dark_oak_door,
-					Blocks.dark_oak_fence_gate,
 					Blocks.daylight_detector,
 					Blocks.daylight_detector_inverted,
 					Blocks.dispenser,
 					Blocks.dropper,
 					Blocks.enchanting_table,
 					Blocks.ender_chest,
-					Blocks.oak_fence_gate,
 					Blocks.furnace,
 					Blocks.hopper,
 					Blocks.jungle_door,
-					Blocks.jungle_fence_gate,
 					Blocks.lever,
 					Blocks.noteblock,
 					Blocks.powered_comparator,
@@ -2820,7 +2816,6 @@ public class DankersSkyblockMod
 					Blocks.wall_sign,
 					Blocks.trapdoor,
 					Blocks.trapped_chest,
-					Blocks.wall_sign,
 					Blocks.wooden_button,
 					Blocks.stone_button,
 					Blocks.oak_door,
@@ -2828,7 +2823,7 @@ public class DankersSkyblockMod
 			));
 			if(Utils.inDungeons) {
 				interactables.add(Blocks.coal_block);
-				interactables.add(Blocks.redstone_block);
+				interactables.add(Blocks.stained_hardened_clay);
 			}
 			if(!interactables.contains(block)) {
 				if (ToggleCommand.aotdToggled && item.getDisplayName().contains("Aspect of the Dragons")) {

--- a/src/main/java/me/Danker/DankersSkyblockMod.java
+++ b/src/main/java/me/Danker/DankersSkyblockMod.java
@@ -2786,7 +2786,7 @@ public class DankersSkyblockMod
 		if(event.action == PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK) {
 			IBlockState blockState = Minecraft.getMinecraft().theWorld.getBlockState(event.pos);
 			Block block = blockState.getBlock();
-			List<Block> interactables = Arrays.asList(
+			ArrayList<Block> interactables = new ArrayList<>(Arrays.asList(
 					Blocks.acacia_door,
 					Blocks.acacia_fence_gate,
 					Blocks.anvil,
@@ -2825,7 +2825,7 @@ public class DankersSkyblockMod
 					Blocks.stone_button,
 					Blocks.oak_door,
 					Blocks.skull
-			);
+			));
 			if(Utils.inDungeons) {
 				interactables.add(Blocks.coal_block);
 				interactables.add(Blocks.redstone_block);

--- a/src/main/java/me/Danker/DankersSkyblockMod.java
+++ b/src/main/java/me/Danker/DankersSkyblockMod.java
@@ -3213,20 +3213,20 @@ public class DankersSkyblockMod
 					}
 
         			Color[] colors = {
-						new Color(255, 0, 0, 60),
-						new Color(0, 0, 255, 60),
-						new Color(60, 179, 113, 60),
-						new Color(255, 114, 255, 60),
-						new Color(255, 199, 87, 60),
-						new Color(119, 105, 198, 60),
-						new Color(135, 199, 112, 60),
-						new Color(260, 37, 260, 60),
-						new Color(178, 132, 190, 60),
-						new Color(63, 135, 163, 60),
-						new Color(146, 74, 10, 60),
-						new Color(255, 255, 255, 60),
-						new Color(217, 252, 160, 60),
-						new Color(255, 82, 82, 60)
+						new Color(255, 0, 0, 100),
+						new Color(0, 0, 255, 100),
+						new Color(100, 179, 113, 100),
+						new Color(255, 114, 255, 100),
+						new Color(255, 199, 87, 100),
+						new Color(119, 105, 198, 100),
+						new Color(135, 199, 112, 100),
+						new Color(2100, 37, 2100, 100),
+						new Color(178, 132, 190, 100),
+						new Color(63, 135, 163, 100),
+						new Color(146, 74, 10, 100),
+						new Color(255, 255, 255, 100),
+						new Color(217, 252, 1100, 100),
+						new Color(255, 82, 82, 100)
 					};
 
 					Iterator<Color> colorIterator = Arrays.stream(colors).iterator();

--- a/src/main/java/me/Danker/DankersSkyblockMod.java
+++ b/src/main/java/me/Danker/DankersSkyblockMod.java
@@ -2830,7 +2830,14 @@ public class DankersSkyblockMod
 				interactables.add(Blocks.coal_block);
 				interactables.add(Blocks.redstone_block);
 			}
-			if(!interactables.contains(block)) if(event.isCancelable()) event.setCanceled(true);
+			if(!interactables.contains(block)) {
+				if (ToggleCommand.aotdToggled && item.getDisplayName().contains("Aspect of the Dragons")) {
+					event.setCanceled(true);
+				}
+				if (ToggleCommand.lividDaggerToggled && item.getDisplayName().contains("Livid Dagger")) {
+					event.setCanceled(true);
+				}
+			}
 		}
     }
 

--- a/src/main/java/me/Danker/DankersSkyblockMod.java
+++ b/src/main/java/me/Danker/DankersSkyblockMod.java
@@ -2826,6 +2826,10 @@ public class DankersSkyblockMod
 					Blocks.oak_door,
 					Blocks.skull
 			);
+			if(Utils.inDungeons) {
+				interactables.add(Blocks.coal_block);
+				interactables.add(Blocks.redstone_block);
+			}
 			if(!interactables.contains(block)) if(event.isCancelable()) event.setCanceled(true);
 		}
     }

--- a/src/main/java/me/Danker/commands/ToggleCommand.java
+++ b/src/main/java/me/Danker/commands/ToggleCommand.java
@@ -36,6 +36,7 @@ public class ToggleCommand extends CommandBase implements ICommand {
 	public static boolean cakeTimerToggled;
 	public static boolean lowHealthNotifyToggled;
 	public static boolean lividSolverToggled;
+	public static boolean stopSalvageStarredToggled;
 	// Puzzle Solvers
 	public static boolean threeManToggled;
 	public static boolean oruoToggled;
@@ -63,7 +64,7 @@ public class ToggleCommand extends CommandBase implements ICommand {
 		return "/" + getCommandName() + " <gparty/coords/golden/slayercount/rngesusalerts/splitfishing/chatmaddox/spiritbearalert/" + 
 										  "aotd/lividdagger/sceptremessages/petcolors/dungeontimer/golemalerts/expertiselore/skill50display/" + 
 										  "outlinetext/midasstaffmessages/implosionmessages/healmessages/caketimer/lowhealthnotify/" +
-										  "lividsolver/threemanpuzzle/oruopuzzle/blazepuzzle/creeperpuzzle/waterpuzzle/tictactoepuzzle/" +
+										  "lividsolver/stopsalvagestarred/threemanpuzzle/oruopuzzle/blazepuzzle/creeperpuzzle/waterpuzzle/tictactoepuzzle/" +
 										  "startswithterminal/selectallterminal/itemframeonsealanterns/ultrasequencer/chronomatron/superpairs/pickblockinexperiments/list>";
 	}
 
@@ -80,10 +81,10 @@ public class ToggleCommand extends CommandBase implements ICommand {
 														  "sceptremessages", "petcolors", "dungeontimer", "golemalerts",
 														  "expertiselore", "skill50display", "outlinetext", "midasstaffmessages",
 														  "implosionmessages", "healmessages", "caketimer", "lowhealthnotify",
-														  "lividsolver", "threemanpuzzle", "oruopuzzle", "blazepuzzle",
+														  "lividsolver", "stopsalvagestarred", "threemanpuzzle", "oruopuzzle", "blazepuzzle",
 														  "creeperpuzzle", "waterpuzzle", "tictactoepuzzle", "startswithterminal",
 														  "selectallterminal", "itemframeonsealanterns", "ultrasequencer",
-														  "chronomatron", "superpairs", "list");
+														  "chronomatron", "superpairs", "pickblockinexperiments", "list");
 		}
 		return null;
 	}
@@ -213,6 +214,11 @@ public class ToggleCommand extends CommandBase implements ICommand {
 				lividSolverToggled = !lividSolverToggled;
 				ConfigHandler.writeBooleanConfig("toggles", "LividSolver", lividSolverToggled);
 				player.addChatMessage(new ChatComponentText(DankersSkyblockMod.MAIN_COLOUR + "Livid solver has been set to " + DankersSkyblockMod.SECONDARY_COLOUR + lividSolverToggled + DankersSkyblockMod.MAIN_COLOUR + "."));
+				break;
+			case "stopsalvagestarred":
+				stopSalvageStarredToggled = !stopSalvageStarredToggled;
+				ConfigHandler.writeBooleanConfig("toggles", "StopSalvageStarred", stopSalvageStarredToggled);
+				player.addChatMessage(new ChatComponentText(DankersSkyblockMod.MAIN_COLOUR + "Stop salvaging starred items has been set to " + DankersSkyblockMod.SECONDARY_COLOUR + stopSalvageStarredToggled + DankersSkyblockMod.MAIN_COLOUR + "."));
 				break;
 			case "threemanpuzzle":
 				threeManToggled = !threeManToggled;

--- a/src/main/java/me/Danker/commands/ToggleCommand.java
+++ b/src/main/java/me/Danker/commands/ToggleCommand.java
@@ -51,6 +51,7 @@ public class ToggleCommand extends CommandBase implements ICommand {
 	public static boolean ultrasequencerToggled;
 	public static boolean chronomatronToggled;
 	public static boolean superpairsToggled;
+	public static boolean swapToPickBlockInExperimentsToggled;
 	
 	@Override
 	public String getCommandName() {
@@ -63,7 +64,7 @@ public class ToggleCommand extends CommandBase implements ICommand {
 										  "aotd/lividdagger/sceptremessages/petcolors/dungeontimer/golemalerts/expertiselore/skill50display/" + 
 										  "outlinetext/midasstaffmessages/implosionmessages/healmessages/caketimer/lowhealthnotify/" +
 										  "lividsolver/threemanpuzzle/oruopuzzle/blazepuzzle/creeperpuzzle/waterpuzzle/tictactoepuzzle/" +
-										  "startswithterminal/selectallterminal/itemframeonsealanterns/ultrasequencer/chronomatron/superpairs/list>";
+										  "startswithterminal/selectallterminal/itemframeonsealanterns/ultrasequencer/chronomatron/superpairs/pickblockinexperiments/list>";
 	}
 
 	@Override
@@ -272,6 +273,11 @@ public class ToggleCommand extends CommandBase implements ICommand {
 				superpairsToggled = !superpairsToggled;
 				ConfigHandler.writeBooleanConfig("toggles", "Superpairs", superpairsToggled);
 				player.addChatMessage(new ChatComponentText(DankersSkyblockMod.MAIN_COLOUR + "Superpairs solver has been set to " + DankersSkyblockMod.SECONDARY_COLOUR + superpairsToggled + DankersSkyblockMod.MAIN_COLOUR + "."));
+				break;
+			case "pickblockinexperiments":
+				swapToPickBlockInExperimentsToggled = !swapToPickBlockInExperimentsToggled;
+				ConfigHandler.writeBooleanConfig("toggles", "PickBlockInExperiments", superpairsToggled);
+				player.addChatMessage(new ChatComponentText(DankersSkyblockMod.MAIN_COLOUR + "Auto-swap to pick block in experiments has been set to " + DankersSkyblockMod.SECONDARY_COLOUR + swapToPickBlockInExperimentsToggled + DankersSkyblockMod.MAIN_COLOUR + "."));
 				break;
 			case "list":
 				player.addChatMessage(new ChatComponentText(DankersSkyblockMod.TYPE_COLOUR + "Guild party notifications: " + DankersSkyblockMod.VALUE_COLOUR + gpartyToggled + "\n" +

--- a/src/main/java/me/Danker/gui/DankerGui.java
+++ b/src/main/java/me/Danker/gui/DankerGui.java
@@ -53,6 +53,7 @@ public class DankerGui extends GuiScreen {
 	private GuiButton cakeTimer;
 	private GuiButton lowHealthNotify;
 	private GuiButton lividSolver;
+	private GuiButton stopSalvageStarred;
 	
 	public DankerGui(int page) {
 		this.page = page;
@@ -110,7 +111,9 @@ public class DankerGui extends GuiScreen {
 		golemAlerts = new GuiButton(0, width / 2 - 100, (int) (height * 0.5), "Alert When Golem Spawns: " + Utils.getColouredBoolean(ToggleCommand.golemAlertToggled));
 		rngesusAlert = new GuiButton(0, width / 2 - 100, (int) (height * 0.6), "RNGesus Alerts: " + Utils.getColouredBoolean(ToggleCommand.rngesusAlerts));
 		lowHealthNotify = new GuiButton(0, width / 2 - 100, (int) (height * 0.7), "Low Health Notifications: " + Utils.getColouredBoolean(ToggleCommand.lowHealthNotifyToggled));
-		
+		// Page 5
+		stopSalvageStarred = new GuiButton(0, width / 2 - 100, (int) (height * 0.1), "Stop Salvaging Starred Items: " + Utils.getColouredBoolean(ToggleCommand.stopSalvageStarredToggled));
+
 		switch (page) {
 			case 1:
 				this.buttonList.add(changeDisplay);
@@ -152,6 +155,11 @@ public class DankerGui extends GuiScreen {
 				this.buttonList.add(golemAlerts);
 				this.buttonList.add(rngesusAlert);
 				this.buttonList.add(lowHealthNotify);
+				this.buttonList.add(nextPage);
+				this.buttonList.add(backPage);
+				break;
+			case 5:
+				this.buttonList.add(stopSalvageStarred);
 				this.buttonList.add(backPage);
 				break;
 		}
@@ -164,7 +172,7 @@ public class DankerGui extends GuiScreen {
 	@Override
 	public void drawScreen(int mouseX, int mouseY, float partialTicks) {
 		this.drawDefaultBackground();
-		String pageText = "Page: " + page + "/4";
+		String pageText = "Page: " + page + "/5";
 		int pageWidth = mc.fontRendererObj.getStringWidth(pageText);
 		new TextRenderer(mc, pageText, width / 2 - pageWidth / 2, 10, 1D);
 		super.drawScreen(mouseX, mouseY, partialTicks);
@@ -292,6 +300,10 @@ public class DankerGui extends GuiScreen {
 			ToggleCommand.implosionMessages = !ToggleCommand.implosionMessages;
 			ConfigHandler.writeBooleanConfig("toggles", "ImplosionMessages", ToggleCommand.implosionMessages);
 			implosionMessages.displayString = "Implosion Messages: " + Utils.getColouredBoolean(ToggleCommand.implosionMessages);
+		} else if(button == stopSalvageStarred) {
+			ToggleCommand.stopSalvageStarredToggled = !ToggleCommand.stopSalvageStarredToggled;
+			ConfigHandler.writeBooleanConfig("toggles", "StopSalvageStarred", ToggleCommand.stopSalvageStarredToggled);
+			stopSalvageStarred.displayString = "Stop Salvaging Starred Items: " + Utils.getColouredBoolean(ToggleCommand.stopSalvageStarredToggled);
 		}
 	}
 	

--- a/src/main/java/me/Danker/gui/ExperimentsGui.java
+++ b/src/main/java/me/Danker/gui/ExperimentsGui.java
@@ -15,6 +15,7 @@ public class ExperimentsGui extends GuiScreen {
     private GuiButton ultrasequencer;
     private GuiButton chronomatron;
     private GuiButton superpairs;
+    private GuiButton pickBlock;
 
     @Override
     public boolean doesGuiPauseGame() {
@@ -33,11 +34,14 @@ public class ExperimentsGui extends GuiScreen {
         ultrasequencer = new GuiButton(0, width / 2 - 100, (int) (height * 0.1), "Ultrasequencer Solver: " + Utils.getColouredBoolean(ToggleCommand.ultrasequencerToggled));
         chronomatron = new GuiButton(0, width / 2 - 100, (int) (height * 0.2), "Chronomatron Solver: " + Utils.getColouredBoolean(ToggleCommand.chronomatronToggled));
         superpairs = new GuiButton(0, width / 2 - 100, (int) (height * 0.3), "Superpairs Solver: " + Utils.getColouredBoolean(ToggleCommand.superpairsToggled));
+        pickBlock = new GuiButton(0, width / 2 - 100, (int) (height * 0.4), "Auto-Swap to Pick Block: " + Utils.getColouredBoolean(ToggleCommand.swapToPickBlockInExperimentsToggled));
+
 
         this.buttonList.add(goBack);
         this.buttonList.add(ultrasequencer);
         this.buttonList.add(chronomatron);
         this.buttonList.add(superpairs);
+        this.buttonList.add(pickBlock);
     }
 
     @Override
@@ -62,6 +66,10 @@ public class ExperimentsGui extends GuiScreen {
             ToggleCommand.superpairsToggled = !ToggleCommand.superpairsToggled;
             ConfigHandler.writeBooleanConfig("toggles", "Superpairs", ToggleCommand.superpairsToggled);
             superpairs.displayString = "Superpairs Solver: " + Utils.getColouredBoolean(ToggleCommand.superpairsToggled);
+        } else if (button == pickBlock) {
+            ToggleCommand.swapToPickBlockInExperimentsToggled = !ToggleCommand.swapToPickBlockInExperimentsToggled;
+            ConfigHandler.writeBooleanConfig("toggles", "PickBlockInExperiments", ToggleCommand.swapToPickBlockInExperimentsToggled);
+            pickBlock.displayString = "Auto-Swap to Pick Block: " + Utils.getColouredBoolean(ToggleCommand.swapToPickBlockInExperimentsToggled);
         }
     }
 

--- a/src/main/java/me/Danker/handlers/ConfigHandler.java
+++ b/src/main/java/me/Danker/handlers/ConfigHandler.java
@@ -191,6 +191,7 @@ public class ConfigHandler {
 		if (!hasKey("toggles", "CakeTimer")) writeBooleanConfig("toggles", "CakeTimer", false);
 		if (!hasKey("toggles", "LowHealthNotify")) writeBooleanConfig("toggles", "LowHealthNotify", false);
 		if (!hasKey("toggles", "LividSolver")) writeBooleanConfig("toggles", "LividSolver", false);
+		if (!hasKey("toggles", "StopSalvageStarred")) writeBooleanConfig("toggles", "StopSalvageStarred", false);
 		// Puzzle Solvers
 		if (!hasKey("toggles", "ThreeManPuzzle")) writeBooleanConfig("toggles", "ThreeManPuzzle", false);
 		if (!hasKey("toggles", "OruoPuzzle")) writeBooleanConfig("toggles", "OruoPuzzle", false);
@@ -437,6 +438,7 @@ public class ConfigHandler {
 		ToggleCommand.cakeTimerToggled = getBoolean("toggles", "CakeTimer");
 		ToggleCommand.lowHealthNotifyToggled = getBoolean("toggles", "LowHealthNotify");
 		ToggleCommand.lividSolverToggled = getBoolean("toggles", "LividSolver");
+		ToggleCommand.stopSalvageStarredToggled = getBoolean("toggles", "StopSalvageStarred");
 		// Puzzle Solvers
 		ToggleCommand.threeManToggled = getBoolean("toggles", "ThreeManPuzzle");
 		ToggleCommand.oruoToggled = getBoolean("toggles", "OruoPuzzle");

--- a/src/main/java/me/Danker/handlers/ConfigHandler.java
+++ b/src/main/java/me/Danker/handlers/ConfigHandler.java
@@ -204,6 +204,8 @@ public class ConfigHandler {
 		if (!hasKey("toggles", "UltraSequencer")) writeBooleanConfig("toggles", "UltraSequencer", false);
 		if (!hasKey("toggles", "Chronomatron")) writeBooleanConfig("toggles", "Chronomatron", false);
 		if (!hasKey("toggles", "Superpairs")) writeBooleanConfig("toggles", "Superpairs", false);
+		if (!hasKey("toggles", "PickBlockInExperiments")) writeBooleanConfig("toggles", "PickBlockInExperiments", false);
+
 
 		if (!hasKey("api", "APIKey")) writeStringConfig("api", "APIKey", "");
 		
@@ -448,6 +450,7 @@ public class ConfigHandler {
 		ToggleCommand.ultrasequencerToggled = getBoolean("toggles", "UltraSequencer");
 		ToggleCommand.chronomatronToggled = getBoolean("toggles", "Chronomatron");
 		ToggleCommand.superpairsToggled = getBoolean("toggles", "Superpairs");
+		ToggleCommand.swapToPickBlockInExperimentsToggled = getBoolean("toggles", "PickBlockInExperiments");
 
 		String onlySlayer = getString("toggles", "BlockSlayer");
 		if (!onlySlayer.equals("")) {


### PR DESCRIPTION
Changes: 
- Fix issue #25: Block interacting with a block while holding Livid Dagger or AOTD if the block isn't interactable
- Change opacity of Superpairs matches to 40-50%

Features:
- Auto swap to pick block during experiments: switches LMB to pick block during experiments and swaps to original pick block key after experiment ends.
- Block Salvaging Starred items, checks if the item under the mouse or the item in salvage gui has a star, if so cancel the event (doesn't always work if the user spam clicks the item)
