### PR TITLE
Minor Fixes

### DIFF
--- a/src/main/java/me/Danker/DankersSkyblockMod.java
+++ b/src/main/java/me/Danker/DankersSkyblockMod.java
@@ -721,10 +721,10 @@ public class DankersSkyblockMod {
                                 Utils.createTitle(EnumChatFormatting.YELLOW + "YELLOW PILLAR!", 2);
                                 break;
                             case 5:
-                                Utils.createTitle(EnumChatFormatting.GREEN + "LIME PILLAR!", 2);
+                                Utils.createTitle(EnumChatFormatting.DARK_GREEN + "GREEN PILLAR!", 2);
                                 break;
                             case 11:
-                                Utils.createTitle(EnumChatFormatting.BLUE + "BLUE PILLAR!", 2);
+                                Utils.createTitle(EnumChatFormatting.DARK_PURPLE + "PURPLE PILLAR!", 2);
                                 break;
                             default:
                                 Utils.createTitle(EnumChatFormatting.WHITE + "NECRON STUNNED!", 2);
@@ -3726,7 +3726,7 @@ public class DankersSkyblockMod {
                 if (ToggleCommand.startsWithToggled && Utils.inDungeons && displayName.startsWith("What starts with:")) {
                     char letter = displayName.charAt(displayName.indexOf("'") + 1);
                     for (Slot slot : invSlots) {
-                        if (slot.getSlotIndex() > 53) continue;
+                        if (slot.inventory == mc.thePlayer.inventory) continue;
                         ItemStack item = slot.getStack();
                         if (item == null) continue;
                         if (item.isItemEnchanted()) continue;
@@ -3747,7 +3747,7 @@ public class DankersSkyblockMod {
                     terminalColorNeeded = colour;
 
                     for (Slot slot : invSlots) {
-                        if (slot.getSlotIndex() > 53) continue;
+                        if (slot.inventory == mc.thePlayer.inventory) continue;
                         ItemStack item = slot.getStack();
                         if (item == null) continue;
                         if (item.isItemEnchanted()) continue;

--- a/src/main/java/me/Danker/DankersSkyblockMod.java
+++ b/src/main/java/me/Danker/DankersSkyblockMod.java
@@ -572,8 +572,8 @@ public class DankersSkyblockMod {
 							}
 						}
 						timeSinceGained = System.currentTimeMillis() / 1000;
-						
-						int limit = section.contains("Farming") || section.contains("Enchanting") ? 60 : 50;
+
+                        int limit = section.contains("Farming") || section.contains("Enchanting") || section.contains("Mining") ? 60 : 50;
 						double currentXP = Double.parseDouble(section.substring(section.indexOf("(") + 1, section.indexOf("/")).replace(",", ""));
     					int xpToLevelUp = Integer.parseInt(section.substring(section.indexOf("/") + 1, section.indexOf(")")).replaceAll(",", ""));
     					xpLeft = xpToLevelUp - currentXP;
@@ -641,7 +641,7 @@ public class DankersSkyblockMod {
     					double currentXp = Double.parseDouble(section.substring(section.indexOf("(") + 1, section.indexOf("/")).replace(",", ""));
     					int limit;
     					int totalXp;
-    					if (section.contains("Farming") || section.contains("Enchanting")) {
+                        if (section.contains("Farming") || section.contains("Enchanting") || section.contains("Mining")) {
     						limit = 60;
     						totalXp = 111672425;
     					} else {

--- a/src/main/java/me/Danker/DankersSkyblockMod.java
+++ b/src/main/java/me/Danker/DankersSkyblockMod.java
@@ -416,6 +416,8 @@ public class DankersSkyblockMod {
     public void onWorldChange(WorldEvent.Load event) {
         foundLivid = false;
         livid = null;
+        lowestBlaze = null;
+        highestBlaze = null;
         nextBonzoUse = 0;
     }
 
@@ -3143,7 +3145,7 @@ public class DankersSkyblockMod {
 
     @SubscribeEvent
     public void onWorldRender(RenderWorldLastEvent event) {
-        if (ToggleCommand.blazeToggled) {
+        if (ToggleCommand.blazeToggled && Utils.inDungeons) {
             if (lowestBlaze != null) {
                 BlockPos stringPos = new BlockPos(lowestBlaze.posX, lowestBlaze.posY + 1, lowestBlaze.posZ);
                 Utils.draw3DString(stringPos, EnumChatFormatting.BOLD + "Smallest", LOWEST_BLAZE_COLOUR, event.partialTicks);

--- a/src/main/java/me/Danker/commands/PetsCommand.java
+++ b/src/main/java/me/Danker/commands/PetsCommand.java
@@ -16,20 +16,21 @@ import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.EnumChatFormatting;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 public class PetsCommand extends CommandBase {
 
 	static int petXpToLevel(double xp, String rarity) {
 		int[] xpPerLevel = {100, 110, 120, 130, 145, 160, 175, 190, 210, 230, 250, 275, 300, 330, 360, 400, 440, 490, 540, 600, 660, 730,
-							800, 880, 960, 1050, 1150, 1260, 1380, 1510, 1650, 1800, 1960, 2130, 2310, 2500, 2700, 2920, 3160, 3420, 3700,
-							4000, 4350, 4750, 5200, 5700, 6300, 7000, 7800, 8700, 9700, 10800, 12000, 13300, 14700, 16200, 17800, 19500,
-							21300, 23200, 25200, 27400, 29800, 32400, 35200, 38200, 41400, 44800, 48400, 52200, 56200, 60400, 64800, 69400,
-							74200, 79200, 84700, 90700, 97200, 104200, 111700, 119700, 128200, 137200, 146700, 156700, 167700, 179700, 192700,
-							206700, 221700, 237700, 254700, 272700, 291700, 311700, 333700, 357700, 383700, 411700, 441700, 476700, 516700,
-							561700, 611700, 666700, 726700, 791700, 861700, 936700, 1016700, 1101700, 1191700, 1286700, 1386700, 1496700,
-							1616700, 1746700, 1886700};
-		
+				800, 880, 960, 1050, 1150, 1260, 1380, 1510, 1650, 1800, 1960, 2130, 2310, 2500, 2700, 2920, 3160, 3420, 3700,
+				4000, 4350, 4750, 5200, 5700, 6300, 7000, 7800, 8700, 9700, 10800, 12000, 13300, 14700, 16200, 17800, 19500,
+				21300, 23200, 25200, 27400, 29800, 32400, 35200, 38200, 41400, 44800, 48400, 52200, 56200, 60400, 64800, 69400,
+				74200, 79200, 84700, 90700, 97200, 104200, 111700, 119700, 128200, 137200, 146700, 156700, 167700, 179700, 192700,
+				206700, 221700, 237700, 254700, 272700, 291700, 311700, 333700, 357700, 383700, 411700, 441700, 476700, 516700,
+				561700, 611700, 666700, 726700, 791700, 861700, 936700, 1016700, 1101700, 1191700, 1286700, 1386700, 1496700,
+				1616700, 1746700, 1886700};
+
 		int levelOffset = 0;
 		switch (rarity) {
 			case "UNCOMMON":
@@ -44,8 +45,11 @@ public class PetsCommand extends CommandBase {
 			case "LEGENDARY":
 				levelOffset = 20;
 				break;
+			case "MYTHIC":
+				levelOffset = 20;
+				break;
 		}
-		
+
 		for (int i = levelOffset, xpAdded = 0; i < levelOffset + 99; i++) {
 			xpAdded += xpPerLevel[i];
 			if (xp < xpAdded) {
@@ -54,7 +58,67 @@ public class PetsCommand extends CommandBase {
 		}
 		return 100;
 	}
-	
+
+	enum Rarity {
+		COMMON,
+		UNCOMMON,
+		RARE,
+		EPIC,
+		LEGENDARY,
+		MYTHIC;
+
+		public Rarity nextRarity() {
+			if (this.ordinal() == Rarity.values().length) return this;
+			return Rarity.values()[this.ordinal() + 1];
+		}
+
+		public EnumChatFormatting getChatColor() {
+			if (this == Rarity.COMMON) return EnumChatFormatting.WHITE;
+			if (this == Rarity.UNCOMMON) return EnumChatFormatting.GREEN;
+			if (this == Rarity.RARE) return EnumChatFormatting.BLUE;
+			if (this == Rarity.EPIC) return EnumChatFormatting.DARK_PURPLE;
+			if (this == Rarity.LEGENDARY) return EnumChatFormatting.GOLD;
+			if (this == Rarity.MYTHIC) return EnumChatFormatting.LIGHT_PURPLE;
+			return null;
+		}
+	}
+
+	class Pet {
+
+		public Rarity rarity;
+		public double xp;
+		public boolean active;
+		public boolean rarityBoosted = false;
+		public String name;
+
+		Pet(JsonObject pet) {
+			Rarity rarity = Rarity.valueOf(pet.get("tier").getAsString());
+			if (!pet.get("heldItem").isJsonNull()) {
+				String petItemID = pet.get("heldItem").getAsString();
+				switch (petItemID) {
+					case "PET_ITEM_VAMPIRE_FANG":
+					case "PET_ITEM_TOY_JERRY":
+					case "PET_ITEM_TIER_BOOST":
+						rarityBoosted = true;
+						rarity = rarity.nextRarity();
+				}
+			}
+			this.active = pet.get("active").getAsBoolean();
+			this.name = Utils.capitalizeString(pet.get("type").getAsString());;
+			this.rarity = rarity;
+			this.xp = pet.get("exp").getAsDouble();
+		}
+
+		public String getStringToAdd() {
+			int level = petXpToLevel(this.xp, this.rarity.name());
+
+			String messageToAdd = rarity.getChatColor() + " " + (this.active ? EnumChatFormatting.BOLD + ">>> " : "") + Utils.capitalizeString(this.rarity.name()) + (this.rarityBoosted ? " ⇑" : "")  + " " + this.name + " (" + level + ")" + (this.active ? " <<<" : "");
+
+			return messageToAdd + "\n";
+		}
+
+	}
+
 	@Override
 	public String getCommandName() {
 		return "petsof";
@@ -64,12 +128,12 @@ public class PetsCommand extends CommandBase {
 	public String getCommandUsage(ICommandSender arg0) {
 		return "/" + getCommandName() + " [name]";
 	}
-	
+
 	@Override
 	public int getRequiredPermissionLevel() {
 		return 0;
 	}
-	
+
 	@Override
 	public List<String> addTabCompletionOptions(ICommandSender sender, String[] args, BlockPos pos) {
 		if (args.length == 1) {
@@ -83,13 +147,13 @@ public class PetsCommand extends CommandBase {
 		// MULTI THREAD DRIFTING
 		new Thread(() -> {
 			EntityPlayer player = (EntityPlayer) arg0;
-			
+
 			// Check key
 			String key = ConfigHandler.getString("api", "APIKey");
 			if (key.equals("")) {
 				player.addChatMessage(new ChatComponentText(DankersSkyblockMod.ERROR_COLOUR + "API key not set. Use /setkey."));
 			}
-			
+
 			// Get UUID for Hypixel API requests
 			String username;
 			String uuid;
@@ -102,11 +166,11 @@ public class PetsCommand extends CommandBase {
 				player.addChatMessage(new ChatComponentText(DankersSkyblockMod.MAIN_COLOUR + "Checking pets of " + DankersSkyblockMod.SECONDARY_COLOUR + username));
 				uuid = APIHandler.getUUID(username);
 			}
-			
+
 			// Find stats of latest profile
 			String latestProfile = APIHandler.getLatestProfileID(uuid, key);
 			if (latestProfile == null) return;
-			
+
 			String profileURL = "https://api.hypixel.net/skyblock/profile?profile=" + latestProfile + "&key=" + key;
 			System.out.println("Fetching profile...");
 			JsonObject profileResponse = APIHandler.getResponse(profileURL);
@@ -115,136 +179,40 @@ public class PetsCommand extends CommandBase {
 				player.addChatMessage(new ChatComponentText(DankersSkyblockMod.ERROR_COLOUR + "Failed with reason: " + reason));
 				return;
 			}
-			
+
 			System.out.println("Fetching pets...");
 			JsonArray petsArray = profileResponse.get("profile").getAsJsonObject().get("members").getAsJsonObject().get(uuid).getAsJsonObject().get("pets").getAsJsonArray();
 			if (petsArray.size() == 0) {
 				player.addChatMessage(new ChatComponentText(DankersSkyblockMod.ERROR_COLOUR + username + " has no pets."));
 				return;
 			}
-			
+
 			System.out.println("Looping through pets...");
 			// Push each pet into list
-			List<JsonElement> sortedPets = new ArrayList<>();
+			List<Pet> pets = new ArrayList<>();
 			for (JsonElement petElement : petsArray) {
-				sortedPets.add(petElement);
+				pets.add(new Pet(petElement.getAsJsonObject()));
 			}
-			
-			// Sort pets by exp
-			sortedPets.sort((pet1, pet2) -> {
-				double petXp1 = pet1.getAsJsonObject().get("exp").getAsDouble();
-				double petXp2 = pet2.getAsJsonObject().get("exp").getAsDouble();
-				return -Double.compare(petXp1, petXp2);
-			});
-			
-			// Sort pets into rarities
-			List<JsonObject> commonPets = new ArrayList<>();
-			List<JsonObject> uncommonPets = new ArrayList<>();
-			List<JsonObject> rarePets = new ArrayList<>();
-			List<JsonObject> epicPets = new ArrayList<>();
-			List<JsonObject> legendaryPets = new ArrayList<>();
-			
-			for (JsonElement petElement : sortedPets) {
-				JsonObject pet = petElement.getAsJsonObject();
-				String rarity = pet.get("tier").getAsString();
 
-				switch (rarity) {
-					case "COMMON":
-						commonPets.add(pet);
-						break;
-					case "UNCOMMON":
-						uncommonPets.add(pet);
-						break;
-					case "RARE":
-						rarePets.add(pet);
-						break;
-					case "EPIC":
-						epicPets.add(pet);
-						break;
-					case "LEGENDARY":
-						legendaryPets.add(pet);
-						break;
-				}
-			}
-			
-			int totalPets = commonPets.size() + uncommonPets.size() + rarePets.size() + epicPets.size() + legendaryPets.size();
+			// Sort pets by exp and rarity
+			pets.sort((pet1, pet2) -> {
+				int rarity = pet1.rarity.compareTo(pet2.rarity);
+				int xp = Double.compare(pet1.xp, pet2.xp);
+				if (rarity != 0) return -rarity;
+				return -xp;
+			});
+
 			String finalMessage = DankersSkyblockMod.DELIMITER_COLOUR + "" + EnumChatFormatting.BOLD + "-------------------\n" +
-					  			  EnumChatFormatting.AQUA + " " + username + "'s Pets (" + totalPets + "):\n";
-			
-			// Loop through pet rarities
-			for (JsonObject legPet : legendaryPets) {
-				String petName = Utils.capitalizeString(legPet.get("type").getAsString());
-				int level = petXpToLevel(legPet.get("exp").getAsDouble(), "LEGENDARY");
-				
-				String messageToAdd;
-				if (legPet.get("active").getAsBoolean()) {
-					messageToAdd = EnumChatFormatting.GOLD + " " + EnumChatFormatting.BOLD + ">>> Legendary " + petName + " (" + level + ") <<<";
-				} else {
-					messageToAdd = EnumChatFormatting.GOLD + " Legendary " + petName + " (" + level + ")";
-				}
-				
-				finalMessage += messageToAdd + "\n";
+					EnumChatFormatting.AQUA + " " + username + "'s Pets (" + pets.size() + "):\n";
+
+			// Loop through pets
+			for(Pet pet : pets) {
+				finalMessage += pet.getStringToAdd();
 			}
-			
-			for (JsonObject epicPet: epicPets) {
-				String petName = Utils.capitalizeString(epicPet.get("type").getAsString());
-				int level = petXpToLevel(epicPet.get("exp").getAsDouble(), "EPIC");
-				
-				String messageToAdd;
-				if (epicPet.get("active").getAsBoolean()) {
-					messageToAdd = EnumChatFormatting.DARK_PURPLE + " " + EnumChatFormatting.BOLD + ">>> Epic " + petName + " (" + level + ") <<<";
-				} else {
-					messageToAdd = EnumChatFormatting.DARK_PURPLE + " Epic " + petName + " (" + level + ")";
-				}
-				
-				finalMessage += messageToAdd + "\n";
-			}
-			
-			for (JsonObject rarePet: rarePets) {
-				String petName = Utils.capitalizeString(rarePet.get("type").getAsString());
-				int level = petXpToLevel(rarePet.get("exp").getAsDouble(), "RARE");
-				
-				String messageToAdd;
-				if (rarePet.get("active").getAsBoolean()) {
-					messageToAdd = EnumChatFormatting.BLUE + " " + EnumChatFormatting.BOLD + ">>> Rare " + petName + " (" + level + ") <<<";
-				} else {
-					messageToAdd = EnumChatFormatting.BLUE + " Rare " + petName + " (" + level + ")";
-				}
-				
-				finalMessage += messageToAdd + "\n";
-			}
-			
-			for (JsonObject uncommonPet: uncommonPets) {
-				String petName = Utils.capitalizeString(uncommonPet.get("type").getAsString());
-				int level = petXpToLevel(uncommonPet.get("exp").getAsDouble(), "UNCOMMON");
-				
-				String messageToAdd;
-				if (uncommonPet.get("active").getAsBoolean()) {
-					messageToAdd = EnumChatFormatting.GREEN + " " + EnumChatFormatting.BOLD + ">>> Uncommon " + petName + " (" + level + ") <<<";
-				} else {
-					messageToAdd = EnumChatFormatting.GREEN + " Uncommon " + petName + " (" + level + ")";
-				}
-				
-				finalMessage += messageToAdd + "\n";
-			}
-			
-			for (JsonObject commonPet: commonPets) {
-				String petName = Utils.capitalizeString(commonPet.get("type").getAsString());
-				int level = petXpToLevel(commonPet.get("exp").getAsDouble(), "COMMON");
-				
-				String messageToAdd;
-				if (commonPet.get("active").getAsBoolean()) {
-					messageToAdd = EnumChatFormatting.BOLD + ">>> Common " + petName + " (" + level + ") <<<";
-				} else {
-					messageToAdd = " Common " + petName + " (" + level + ")";
-				}
-				
-				finalMessage += messageToAdd + "\n";
-			}
-			
+
 			finalMessage += DankersSkyblockMod.DELIMITER_COLOUR + " " + EnumChatFormatting.BOLD + "-------------------";
 			player.addChatMessage(new ChatComponentText(finalMessage));
-				
+
 		}).start();
 	}
 

--- a/src/main/java/me/Danker/commands/ResetLootCommand.java
+++ b/src/main/java/me/Danker/commands/ResetLootCommand.java
@@ -24,7 +24,7 @@ public class ResetLootCommand extends CommandBase {
 
 	@Override
 	public String getCommandUsage(ICommandSender arg0) {
-		return "/" + getCommandName() + "<zombie/spider/wolf/fishing/catacombs/confirm/cancel>";
+		return "/" + getCommandName() + "<zombie/spider/wolf/fishing/mythological/catacombs/confirm/cancel>";
 	}
 
 	@Override

--- a/src/main/java/me/Danker/commands/SkillsCommand.java
+++ b/src/main/java/me/Danker/commands/SkillsCommand.java
@@ -96,7 +96,7 @@ public class SkillsCommand extends CommandBase {
 					farmingLevel = (double) Math.round(farmingLevel * 100) / 100;
 				}
 				if (userObject.has("experience_skill_mining")) {
-					miningLevel = Utils.xpToSkillLevel(userObject.get("experience_skill_mining").getAsDouble(), 50);
+					miningLevel = Utils.xpToSkillLevel(userObject.get("experience_skill_mining").getAsDouble(), 60);
 					miningLevel = (double) Math.round(miningLevel * 100) / 100;
 				}
 				if (userObject.has("experience_skill_combat")) {

--- a/src/main/java/me/Danker/commands/SkyblockPlayersCommand.java
+++ b/src/main/java/me/Danker/commands/SkyblockPlayersCommand.java
@@ -70,6 +70,7 @@ public class SkyblockPlayersCommand extends CommandBase {
 			int park = 0; // foraging_1
 			int goldMine = 0; // mining_1
 			int deepCaverns = 0; // mining_2
+			int dwarvenMines = 0; // mining_3
 			int spidersDen = 0; // combat_1
 			int blazingFortress = 0; // combat_2
 			int end = 0; // combat_3
@@ -100,6 +101,9 @@ public class SkyblockPlayersCommand extends CommandBase {
 				}
 				if (skyblockPlayers.has("mining_2")) {
 					deepCaverns = skyblockPlayers.get("mining_2").getAsInt();
+				}
+				if (skyblockPlayers.has("mining_3")) {
+					dwarvenMines = skyblockPlayers.get("mining_3").getAsInt();
 				}
 				if (skyblockPlayers.has("combat_1")) {
 					spidersDen = skyblockPlayers.get("combat_1").getAsInt();
@@ -135,6 +139,7 @@ public class SkyblockPlayersCommand extends CommandBase {
 														DankersSkyblockMod.TYPE_COLOUR + " Park: " + DankersSkyblockMod.VALUE_COLOUR + nf.format(park) + " / " + Utils.getPercentage(park, skyblockTotalPlayers) + "%\n" +
 														DankersSkyblockMod.TYPE_COLOUR + " Gold Mine: " + DankersSkyblockMod.VALUE_COLOUR + nf.format(goldMine) + " / " + Utils.getPercentage(goldMine, skyblockTotalPlayers) + "%\n" +
 														DankersSkyblockMod.TYPE_COLOUR + " Deep Caverns: " + DankersSkyblockMod.VALUE_COLOUR + nf.format(deepCaverns) + " / " + Utils.getPercentage(deepCaverns, skyblockTotalPlayers) + "%\n" +
+														DankersSkyblockMod.TYPE_COLOUR + " Dwarven Mines: " + DankersSkyblockMod.VALUE_COLOUR + nf.format(dwarvenMines) + " / " + Utils.getPercentage(dwarvenMines, skyblockTotalPlayers) + "%\n" +
 														DankersSkyblockMod.TYPE_COLOUR + " Spider's Den: " + DankersSkyblockMod.VALUE_COLOUR + nf.format(spidersDen) + " / " + Utils.getPercentage(spidersDen, skyblockTotalPlayers) + "%\n" +
 														DankersSkyblockMod.TYPE_COLOUR + " Blazing Fortress: " + DankersSkyblockMod.VALUE_COLOUR + nf.format(blazingFortress) + " / " + Utils.getPercentage(blazingFortress, skyblockTotalPlayers) + "%\n" +
 														DankersSkyblockMod.TYPE_COLOUR + " The End: " + DankersSkyblockMod.VALUE_COLOUR + nf.format(end) + " / " + Utils.getPercentage(end, skyblockTotalPlayers) + "%\n" +


### PR DESCRIPTION
Basic Fixes, might have missed some.

- Add Mythological to /resetloot's usage
- Update Necron Notif wording
- Fixed highlighted items in inventory
- Mining 60 + Dwarven mines support for /skills, /skyblockplayers and Skill Tracker
- Reworked /pets command to include Mythic pets as well as recognize tier boosted bets