### PR TITLE
Fix Blaze Solver not working and causing lag

### DIFF
--- a/src/main/java/me/Danker/features/puzzlesolvers/BlazeSolver.java
+++ b/src/main/java/me/Danker/features/puzzlesolvers/BlazeSolver.java
@@ -54,7 +54,7 @@ public class BlazeSolver {
                     if (entity.getName().contains("Blaze") && entity.getName().contains("/")) {
                         String blazeName = StringUtils.stripControlCodes(entity.getName());
                         try {
-                            int health = Integer.parseInt(blazeName.substring(blazeName.indexOf("/") + 1, blazeName.length() - 1));
+                            int health = Utils.parseInt(blazeName.substring(blazeName.indexOf("/") + 1, blazeName.length() - 1));
                             if (health > highestHealth) {
                                 highestHealth = health;
                                 highestBlaze = entity;

--- a/src/main/java/me/Danker/utils/Utils.java
+++ b/src/main/java/me/Danker/utils/Utils.java
@@ -580,4 +580,9 @@ public class Utils {
 		return true;
 	}
 
+	public static int parseInt(String integer){
+		String cleanInt = integer.replaceAll("\\D", "");
+		return Integer.parseInt(cleanInt);
+	}
+
 }


### PR DESCRIPTION
Fixed error caused by comma in the amount of blaze health who break the solver and causing extreme lag issue when near to blaze puzzle.